### PR TITLE
chore(): Remove reviewers field in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "rewindio/appsec"
     labels:
       - "appsec"
     open-pull-requests-limit: 10


### PR DESCRIPTION
As the title says. For https://rewind.atlassian.net/browse/DEVOPS-2671.